### PR TITLE
Destroy blog with blog tags

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,10 @@
+Metrics/LineLength:
+  Max: 100
+
+Metrics/ModuleLength:
+  Exclude:
+    - "**/*_spec.rb"
+
+Metrics/BlockLength:
+  Exclude:
+    - "**/*_spec.rb"

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -19,7 +19,7 @@
 
 class Blog < ApplicationRecord
   belongs_to :author, class_name: 'User'
-  has_many :blog_tags
+  has_many :blog_tags, dependent: :destroy
   has_many :tags, through: :blog_tags
 
   validates :title, presence: true, length: { maximum: 64 }

--- a/spec/features/blog_management_spec.rb
+++ b/spec/features/blog_management_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 RSpec.feature 'Blog management', type: :feature do
+  let(:tags) { create_list(:tag, 3) }
   let(:user) { create(:user, :with_identity) }
-  let!(:user_blog) { create(:blog, author: user) }
+  let!(:user_blog) { create(:blog, :tagged, author: user, tags: tags) }
   let!(:user_draft_blog) { create(:blog, :draft, author: user) }
   let(:other_user) { create(:user, :with_identity) }
   let!(:other_user_blog) { create(:blog, author: other_user) }


### PR DESCRIPTION
タグを付けたデータの削除をしたときに、関連のレコードが削除されず、外部参照キーのエラーでロールバックされていた。