### PR TITLE
Add system spec and request spec with my page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/mini_blog
     docker:
-      - image: circleci/ruby:2.6.3-node
+      - image: circleci/ruby:2.6.3-node-browsers
         environment:
           PGHOST: 127.0.0.1
           PGUSER: ubuntu
@@ -15,6 +15,10 @@ jobs:
           POSTGRES_PASSWORD: ""
     steps:
       - checkout
+      - run:
+          name: Run chromedriver
+          command: chromedriver
+          background: true
       - restore_cache:
           name: Restore bundle cache
           key: mini_blog-bundle-{{ checksum "Gemfile.lock" }}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,13 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
 
+  def require_signed_in
+    return if user_signed_in?
+
+    flash[:error] = 'You must be logged in to access this section.'
+    redirect_to root_path
+  end
+
   def markdown_to_html(markdown_text)
     @markdown ||= Redcarpet::Markdown.new(
       markdown_renderer,

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MyController < ApplicationController
+  def index
+    # empty
+  end
+end

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class MyController < ApplicationController
+  before_action :require_signed_in
+
   def index
     # empty
   end

--- a/app/views/my/index.html.haml
+++ b/app/views/my/index.html.haml
@@ -1,0 +1,1 @@
+%h1 My page

--- a/app/views/my/index.html.haml
+++ b/app/views/my/index.html.haml
@@ -1,1 +1,10 @@
 %h1 My page
+
+.row
+  .col-12
+    .card{ style: 'width: 18rem;' }
+      %img.card-img-top{ src: current_user.icon_url, hight: '200', width: '200' }
+
+      .card-body
+        %h2.card-title= current_user.nickname
+        = simple_format current_user.introduction

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   end
   resources :tags, only: %i[index show]
 
+  resources :my, only: :index
+
   get '/sign_up', to: 'sign_up#index'
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/signout', to: 'sessions#destroy', as: :signout

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'support/omniauth_helper'
 require 'support/factory_bot_helper'
+require 'support/sign_in_helper'
 require 'selenium/webdriver'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/requests/my_spec.rb
+++ b/spec/requests/my_spec.rb
@@ -4,9 +4,24 @@ require 'rails_helper'
 
 RSpec.describe 'My', type: :request do
   describe 'GET /my' do
-    it 'works!' do
-      get my_index_path
-      expect(response).to have_http_status(200)
+    context 'When user does not logged in' do
+      it 'is returned 302' do
+        get my_index_path
+        expect(response).to have_http_status(302)
+      end
+    end
+
+    context 'When user logged in' do
+      let(:user) { create(:user, :with_identity) }
+
+      before do
+        sign_in(user)
+      end
+
+      it 'is returned 200 OK' do
+        get my_index_path
+        expect(response).to have_http_status(200)
+      end
     end
   end
 end

--- a/spec/requests/my_spec.rb
+++ b/spec/requests/my_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'My', type: :request do
+  describe 'GET /my' do
+    it 'works!' do
+      get my_index_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/support/sign_in_helper.rb
+++ b/spec/support/sign_in_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+def sign_in(user)
+  allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+end

--- a/spec/system/my_spec.rb
+++ b/spec/system/my_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'My', type: :system do
+  context 'When user does not signed in' do
+    it 'displays warning' do
+      visit my_index_path
+
+      expect(page.text).to have_text('You must be logged in to access this section.')
+    end
+  end
+
+  context 'When user signed in' do
+    let(:user) { create(:user) }
+
+    before do
+      sign_in(user)
+    end
+
+    it 'displays my page' do
+      visit my_index_path
+
+      expect(page.text).to have_text('My page')
+    end
+  end
+end

--- a/spec/system/my_spec.rb
+++ b/spec/system/my_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe 'My', type: :system do
     it 'displays my page' do
       visit my_index_path
 
-      expect(page.text).to have_text('My page')
+      expect(page).to have_text('My page')
+      expect(page).to have_text(user.nickname)
     end
   end
 end


### PR DESCRIPTION
system specとrequest specを使えるようにします。
導入は新しいページとなる、`/my` の追加と同時に行います。
`my` の説明は↓の通り。

ログインユーザの所有する情報を管理する場所を `/users/999/〜` から `/my/〜` に移動していきたい。
ここでは、その起点となるページを追加します。 
