### PR TITLE
Ignore pronto on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,10 @@ workflows:
       - code_analysis:
           requires:
             - prepare
+          filters:
+            branches:
+              ignore:
+                - master
       - test:
           requires:
             - prepare


### PR DESCRIPTION
すでにトピックブランチでチェックされているので重ねてやる必要がないのと、
コメントする先がないため。