### PR TITLE
Use rubocop cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,11 +63,22 @@ jobs:
       - jq/install:
           install-dir: ./bin
       - run:
+          name: rubocop version
+          command: bin/bundle exec rubocop --version > rubocop_version.txt
+      - restore_cache:
+          name: Restore rubocop cache
+          key: rubocop-{{ checksum "rubocop_version.txt" }}
+      - run:
           name: Pronto
           command: |
             export PRONTO_PULL_REQUEST_ID=`echo "${CIRCLE_PULL_REQUEST}" | grep -oE '[0-9]+$'`
             base_branch=`curl -sH "Authorization: token ${PRONTO_GITHUB_ACCESS_TOKEN}" "https://api.github.com/repos/ken1flan/mini_blog/pulls/${PRONTO_PULL_REQUEST_ID}" | jq -r '.base.ref'`
             bin/bundle exec pronto run -f github_pr_review -c origin/${base_branch} --exit-code
+      - save_cache:
+          name: Store rubocop cache
+          key: rubocop-{{ checksum "rubocop_version.txt" }}
+          paths:
+            - ~/.cache/rubocop
   test:
     executor: my-executor
     working_directory: ~/mini_blog


### PR DESCRIPTION
Rubocopは検査結果のキャッシュがあり、デフォルトでONになっています。
circleciでは、毎回クリーンな環境で実行されるので、この恩恵を受けられません。

そこで、Rubocopのキャッシュしたファイルを保存し、次回実行時にレストアし活用してみたいと思います。

rubocopは`--cache`オプションでキャッシュの有無を切り替えられるので、timeコマンドで計測してみました。
自分の環境では、プログラムの実行時間のuserはキャッシュなしで4〜5秒程度、キャッシュありでは1.2〜1.3秒程度でした。
改善が期待できそうなのは3秒程度なので、普段かかっているcircleciの実行時間から考えるとわずかではありますが、積み重ねですので…。

## 参照
https://docs.rubocop.org/rubocop/0.89/usage/caching.html
